### PR TITLE
Remove schema from EventSearch

### DIFF
--- a/lib/eventSearch.js
+++ b/lib/eventSearch.js
@@ -2,10 +2,6 @@
 
 var Promise = require("bluebird");
 var rp = require("request-promise");
-var path = require("path");
-var fs = require("fs");
-
-var schema = JSON.parse(fs.readFileSync(path.join(__dirname, "../", "schema", "events-response.schema.json"), "utf8"));
 
 var EventSearch = function (options) {
     
@@ -13,7 +9,6 @@ var EventSearch = function (options) {
 
     self.allowedSorts = ["time", "distance", "venue", "popularity"];
     self.allowedCategories = ["ARTS_ENTERTAINMENT", "EDUCATION", "FITNESS_RECREATION", "FOOD_BEVERAGE", "HOTEL_LODGING", "MEDICAL_HEALTH", "SHOPPING_RETAIL", "TRAVEL_TRANSPORTATION"];
-    self.schema = schema;
     self.accessToken = (process.env.FEBL_ACCESS_TOKEN && process.env.FEBL_ACCESS_TOKEN !== "" ? process.env.FEBL_ACCESS_TOKEN : null);
 
 };
@@ -376,10 +371,6 @@ EventSearch.prototype.search = function (options) {
 
     });
 
-};
-
-EventSearch.prototype.getSchema = function () {
-    return this.schema;
 };
 
 module.exports = EventSearch;


### PR DESCRIPTION
Schema definition is using fs module, which is not listed in project dependencies nor automatically available in every dependent environment (eg: ionic app). Since schema is being used only for the tests and it is already redefined there, maybe we could just remove it from the main class.