### PR TITLE
Added query option for limiting number of results in location search

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Mandatory parameters are the following:
 Non-mandatory parameters
 
 * `query`: The term(s) on which you want to narrow down your *location search* (this only filters the places, not the events itself!).
+* `limit`: Limits the number of results in your *location search* (this only limits the places, not the events!). Default is `100`. This can be used to speed up response time if you don't want to retrieve the maximum number of events.
 * `categories`: The array of [place categories](https://developers.facebook.com/docs/places/web/search#categories) that should be searched for. Valid entries are `ARTS_ENTERTAINMENT`, `EDUCATION`, `FITNESS_RECREATION`, `FOOD_BEVERAGE`, `HOTEL_LODGING`, `MEDICAL_HEALTH`, `SHOPPING_RETAIL`, `TRAVEL_TRANSPORTATION`. Default is none.  
 * `accessToken`: The **App Access Token** to be used for the requests to the Graph API.
 * `distance`: The distance in meters (it makes sense to use smaller distances, like max. 2500). Default is `100`.

--- a/lib/eventSearch.js
+++ b/lib/eventSearch.js
@@ -96,6 +96,7 @@ EventSearch.prototype.search = function (options) {
     var self = this,
         queryOptions = {};
 
+    queryOptions.limit = options.limit || 100;
     queryOptions.latitude = options.lat || null;
     queryOptions.longitude = options.lng || null;
     queryOptions.distance = options.distance || 100;
@@ -264,7 +265,7 @@ EventSearch.prototype.search = function (options) {
                     "&q=" + queryOptions.query +
                     "&center=" + queryOptions.latitude + "," + queryOptions.longitude +
                     "&distance=" + queryOptions.distance +
-                    "&limit=100" +
+                    "&limit=" + queryOptions.limit +
                     "&fields=id" +
                     "&access_token=" + queryOptions.accessToken;
 


### PR DESCRIPTION
This allows for optimization of query speed when making smaller searches. In my case, only needing 15 events maximum, dropping the limit to 10 doubled the speed and still returned more events than needed.